### PR TITLE
update client path to use latest.deb

### DIFF
--- a/foldingathome.yml
+++ b/foldingathome.yml
@@ -134,8 +134,8 @@ Resources:
             # Install cfn-tools and awscli for health signalling
             pip install aws-cfn-bootstrap awscli
             # Install Folding@home
-            wget https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.6/fahclient_7.6.9_amd64.deb
-            dpkg-deb -x fahclient_7.6.9_amd64.deb /
+            wget https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.6/latest.deb
+            dpkg-deb -x latest.deb /
             mkdir /etc/fahclient
             cat<<END >/etc/fahclient/config.xml
             <config>


### PR DESCRIPTION
Current URL for the F@H client is statically defined to use version 7.6.9.

This PR updates the URL to use latest.deb, which is linked to the latest patch version within the train, rather than the explicit URL; this ensures instances will fetch the latest 7.6 client at creation.

An further expansion could be to allow users to select the major/minor version as a parameter, defaulting to 7.6 (or newer versions as required), though this is not included in this PR.