### PR TITLE
update client URL to dynamically pull latest version

### DIFF
--- a/foldingathome.yml
+++ b/foldingathome.yml
@@ -134,8 +134,8 @@ Resources:
             # Install cfn-tools and awscli for health signalling
             pip install aws-cfn-bootstrap awscli
             # Install Folding@home
-            wget https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.6/fahclient_7.6.9_amd64.deb
-            dpkg-deb -x fahclient_7.6.9_amd64.deb /
+            wget https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.6/latest.deb
+            dpkg-deb -x latest.deb /
             mkdir /etc/fahclient
             cat<<END >/etc/fahclient/config.xml
             <config>

--- a/foldingathome.yml
+++ b/foldingathome.yml
@@ -134,13 +134,10 @@ Resources:
             # Install cfn-tools and awscli for health signalling
             pip install aws-cfn-bootstrap awscli
             # Install Folding@home
-            PATCH_VERSION="$(curl -sL https://download.foldingathome.org/js/fah-downloads.js \
-            | awk -F'(fahclient_|_amd64.deb)' '/debian-stable-64bit/ {print $2;exit}')" && \
-            MAJOR_VERSION="$(curl -sL https://download.foldingathome.org/js/fah-downloads.js \
-            | awk -F'(/debian-stable-64bit/|/fahclient_)' '/debian-stable-64bit/ {print $2;exit}')" && \
-            curl -o \
-            /tmp/latest.deb -L \
-            "https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/${MAJOR_VERSION}/fahclient_${PATCH_VERSION}_amd64.deb"
+            PATCH_VERSION=$(curl -sL https://download.foldingathome.org/js/fah-downloads.js | awk -F'(fahclient_|_amd64.deb)' '/debian-stable-64bit/ {print $2;exit}')
+            MAJOR_VERSION=$(curl -sL https://download.foldingathome.org/js/fah-downloads.js | awk -F'(/debian-stable-64bit/|/fahclient_)' '/debian-stable-64bit/ {print $2;exit}')
+            FAH_URL=https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/${!MAJOR_VERSION}/fahclient_${!PATCH_VERSION}_amd64.deb
+            curl -o /tmp/latest.deb -L ${!FAH_URL}
             dpkg-deb -x /tmp/latest.deb /
             mkdir /etc/fahclient
             cat<<END >/etc/fahclient/config.xml

--- a/foldingathome.yml
+++ b/foldingathome.yml
@@ -134,10 +134,10 @@ Resources:
             # Install cfn-tools and awscli for health signalling
             pip install aws-cfn-bootstrap awscli
             # Install Folding@home
-	    PATCH_VERSION="$(curl -sL https://download.foldingathome.org/js/fah-downloads.js \
+            PATCH_VERSION="$(curl -sL https://download.foldingathome.org/js/fah-downloads.js \
             | awk -F'(fahclient_|_amd64.deb)' '/debian-stable-64bit/ {print $2;exit}')" && \
             MAJOR_VERSION="$(curl -sL https://download.foldingathome.org/js/fah-downloads.js \
-	    | awk -F'(/debian-stable-64bit/|/fahclient_)' '/debian-stable-64bit/ {print $2;exit}')" && \
+            | awk -F'(/debian-stable-64bit/|/fahclient_)' '/debian-stable-64bit/ {print $2;exit}')" && \
             curl -o \
 	    /tmp/latest.deb -L \
 	    "https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/${MAJOR_VERSION}/fahclient_${PATCH_VERSION}_amd64.deb"

--- a/foldingathome.yml
+++ b/foldingathome.yml
@@ -134,8 +134,14 @@ Resources:
             # Install cfn-tools and awscli for health signalling
             pip install aws-cfn-bootstrap awscli
             # Install Folding@home
-            wget https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.6/latest.deb
-            dpkg-deb -x latest.deb /
+            PATCH_VERSION="$(curl -sL https://download.foldingathome.org/js/fah-downloads.js \
+          	| awk -F'(fahclient_|_amd64.deb)' '/debian-stable-64bit/ {print $2;exit}')" && \
+            MAJOR_VERSION="$(curl -sL https://download.foldingathome.org/js/fah-downloads.js \
+	          | awk -F'(/debian-stable-64bit/|/fahclient_)' '/debian-stable-64bit/ {print $2;exit}')" && \
+            curl -o \
+	          /tmp/latest.deb -L \
+	          "https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/${MAJOR_VERSION}/fahclient_${PATCH_VERSION}_amd64.deb"
+            dpkg-deb -x /tmp/latest.deb /
             mkdir /etc/fahclient
             cat<<END >/etc/fahclient/config.xml
             <config>

--- a/foldingathome.yml
+++ b/foldingathome.yml
@@ -135,12 +135,12 @@ Resources:
             pip install aws-cfn-bootstrap awscli
             # Install Folding@home
             PATCH_VERSION="$(curl -sL https://download.foldingathome.org/js/fah-downloads.js \
-          	| awk -F'(fahclient_|_amd64.deb)' '/debian-stable-64bit/ {print $2;exit}')" && \
+            | awk -F'(fahclient_|_amd64.deb)' '/debian-stable-64bit/ {print $2;exit}')" && \
             MAJOR_VERSION="$(curl -sL https://download.foldingathome.org/js/fah-downloads.js \
-	          | awk -F'(/debian-stable-64bit/|/fahclient_)' '/debian-stable-64bit/ {print $2;exit}')" && \
+	    | awk -F'(/debian-stable-64bit/|/fahclient_)' '/debian-stable-64bit/ {print $2;exit}')" && \
             curl -o \
-	          /tmp/latest.deb -L \
-	          "https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/${MAJOR_VERSION}/fahclient_${PATCH_VERSION}_amd64.deb"
+	    /tmp/latest.deb -L \
+	    "https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/${MAJOR_VERSION}/fahclient_${PATCH_VERSION}_amd64.deb"
             dpkg-deb -x /tmp/latest.deb /
             mkdir /etc/fahclient
             cat<<END >/etc/fahclient/config.xml

--- a/foldingathome.yml
+++ b/foldingathome.yml
@@ -134,7 +134,7 @@ Resources:
             # Install cfn-tools and awscli for health signalling
             pip install aws-cfn-bootstrap awscli
             # Install Folding@home
-            PATCH_VERSION="$(curl -sL https://download.foldingathome.org/js/fah-downloads.js \
+	    PATCH_VERSION="$(curl -sL https://download.foldingathome.org/js/fah-downloads.js \
             | awk -F'(fahclient_|_amd64.deb)' '/debian-stable-64bit/ {print $2;exit}')" && \
             MAJOR_VERSION="$(curl -sL https://download.foldingathome.org/js/fah-downloads.js \
 	    | awk -F'(/debian-stable-64bit/|/fahclient_)' '/debian-stable-64bit/ {print $2;exit}')" && \

--- a/foldingathome.yml
+++ b/foldingathome.yml
@@ -139,8 +139,8 @@ Resources:
             MAJOR_VERSION="$(curl -sL https://download.foldingathome.org/js/fah-downloads.js \
             | awk -F'(/debian-stable-64bit/|/fahclient_)' '/debian-stable-64bit/ {print $2;exit}')" && \
             curl -o \
-	    /tmp/latest.deb -L \
-	    "https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/${MAJOR_VERSION}/fahclient_${PATCH_VERSION}_amd64.deb"
+            /tmp/latest.deb -L \
+            "https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/${MAJOR_VERSION}/fahclient_${PATCH_VERSION}_amd64.deb"
             dpkg-deb -x /tmp/latest.deb /
             mkdir /etc/fahclient
             cat<<END >/etc/fahclient/config.xml


### PR DESCRIPTION
The current URL for the F@H client within the template is statically defined to use version 7.6.9.

This PR updates the URL to use a dynamic one, based on scraping of the download.js manifest from the FAH website, ensuring clients are always pulling the latest recommended version.